### PR TITLE
change cycjimmy release action from v3 to v6

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,7 @@ jobs:
       - run: dart pub get
       - run: just
       - name: release
-        uses: cycjimmy/semantic-release-action@v3
+        uses: cycjimmy/semantic-release-action@v6
         with:
           extra_plugins: |
             @semantic-release/exec


### PR DESCRIPTION
The release currently fails because the release action has incompatible npm dependencies. I expect an upgrade to the newest release action to fix that problem. 